### PR TITLE
no-intermediates feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ To bypass tool confirmation requirements, use the `--no-confirmations` flag:
 $ llm --no-confirmations "What is the top article on hackernews today?"
 ```
 
+To use in bash scripts, add the --no-intermediates, so it doesn't print intermediate messages, only the concluding end message.
+```bash
+$ llm --no-intermediates "What is the time in Tokyo right now?"
+```
+
+```bash
+$ llm --no-confirmations "What is the top article on hackernews today?"
+```
+
 ### Continuation
 
 Add a `c ` prefix to your message to continue the last conversation.

--- a/src/mcp_client_cli/cli.py
+++ b/src/mcp_client_cli/cli.py
@@ -46,6 +46,7 @@ class AgentState(TypedDict):
     today_datetime: str
     # The user's memories.
     memories: str = "no memories"
+    remaining_steps: int = 5
 
 async def run() -> None:
     """Run the LLM agent."""
@@ -100,6 +101,8 @@ Examples:
                        help='Print output as raw text instead of parsing markdown')
     parser.add_argument('--no-tools', action='store_true',
                        help='Do not add any tools')
+    parser.add_argument('--no-intermediates', action='store_true',
+                       help='Only print the final message')
     parser.add_argument('--show-memories', action='store_true',
                        help='Show user memories')
     return parser.parse_args()
@@ -234,9 +237,10 @@ async def handle_conversation(args: argparse.Namespace, query: HumanMessage,
             messages=[query], 
             today_datetime=datetime.now().isoformat(),
             memories=formatted_memories,
+            remaining_steps=3
         )
 
-        output = OutputHandler(text_only=args.text_only)
+        output = OutputHandler(text_only=args.text_only, only_last_message=args.no_intermediates)
         output.start()
         try:
             async for chunk in agent_executor.astream(


### PR DESCRIPTION
For use in bash scripts, this flag

--no-intermediates

doesn't print all intermediate messages, only the last message where the script responds to the question using the tool results.