### PR TITLE
Allow to override model choice from bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,6 @@ To use in bash scripts, add the --no-intermediates, so it doesn't print intermed
 $ llm --no-intermediates "What is the time in Tokyo right now?"
 ```
 
-```bash
-$ llm --no-confirmations "What is the top article on hackernews today?"
-```
-
 ### Continuation
 
 Add a `c ` prefix to your message to continue the last conversation.
@@ -171,6 +167,7 @@ $ llm --no-tools                  # Run without any tools
 $ llm --force-refresh             # Force refresh tool capabilities cache
 $ llm --text-only                 # Output raw text without markdown formatting
 $ llm --show-memories             # Show user memories
+$ llm --model gpt-4               # Override the model specified in config
 ```
 
 ## Setup

--- a/src/mcp_client_cli/cli.py
+++ b/src/mcp_client_cli/cli.py
@@ -105,6 +105,8 @@ Examples:
                        help='Only print the final message')
     parser.add_argument('--show-memories', action='store_true',
                        help='Show user memories')
+    parser.add_argument('--model',
+                       help='Override the model specified in config')
     return parser.parse_args()
 
 async def handle_list_tools(app_config: AppConfig, args: argparse.Namespace) -> None:
@@ -201,6 +203,10 @@ async def handle_conversation(args: argparse.Namespace, query: HumanMessage,
     extra_body = {}
     if app_config.llm.base_url and "openrouter" in app_config.llm.base_url:
         extra_body = {"transforms": ["middle-out"]}
+    # Override model if specified in command line
+    if args.model:
+        app_config.llm.model = args.model
+        
     model: BaseChatModel = init_chat_model(
         model=app_config.llm.model,
         model_provider=app_config.llm.provider,


### PR DESCRIPTION
Now you can run `llm --model anthropic/claude-3.5-haiku` along side sonnet for different use cases