### PR TITLE
Fixed bug with agent_executor

### DIFF
--- a/src/mcp_client_cli/cli.py
+++ b/src/mcp_client_cli/cli.py
@@ -232,8 +232,8 @@ async def handle_conversation(args: argparse.Namespace, query: HumanMessage,
         memories = await get_memories(store)
         formatted_memories = "\n".join(f"- {memory}" for memory in memories)
         agent_executor = create_react_agent(
-            model, tools, state_schema=AgentState, 
-            state_modifier=prompt, checkpointer=checkpointer, store=store
+            model, tools, state_schema=AgentState,
+            checkpointer=checkpointer, store=store
         )
         
         thread_id = (await conversation_manager.get_last_id() if is_conversation_continuation 


### PR DESCRIPTION
Fixed the following bug: TypeError: create_react_agent() got an unexpected keyword argument 'system_message'

Error caused by system_message=prompt in the agent_executor creation.
Current version of LangGraph does not accept system_message parameter.